### PR TITLE
split word by any whitespace

### DIFF
--- a/libs/braillify/src/lib.rs
+++ b/libs/braillify/src/lib.rs
@@ -47,7 +47,7 @@ impl Encoder {
 
     pub fn encode(&mut self, text: &str, result: &mut Vec<u8>) -> Result<(), String> {
         let words = text
-            .split(' ')
+            .split_ascii_whitespace()
             .filter(|word| !word.is_empty())
             .collect::<Vec<&str>>();
 


### PR DESCRIPTION
` ` 외에도 `\t`나 `\n` 으로도 단어를 자릅니다 