### PR TITLE
한글 영어 문장 판별 초안

### DIFF
--- a/libs/braillify/src/sentence_analyzer.rs
+++ b/libs/braillify/src/sentence_analyzer.rs
@@ -1,0 +1,80 @@
+use crate::utils;
+
+/// 문장의 언어 주체를 판단하는 분석기
+pub struct SentenceAnalyzer;
+
+impl SentenceAnalyzer {
+    /// 문장을 공백으로 단어 분리
+    pub fn parse_sentence(text: &str) -> Vec<String> {
+        text.split_whitespace()
+            .map(|s| s.to_string())
+            .collect()
+    }
+    
+    /// 단어가 혼합 단어인지 확인 (영어+한글+특수기호)
+    pub fn is_mixed_word(word: &str) -> bool {
+        let has_english = word.chars().any(|c| c.is_ascii_alphabetic());
+        let has_korean = word.chars().any(|c| utils::is_korean_char(c));
+        
+        // 영어와 한글이 모두 있으면 혼합 단어
+        has_english && has_korean
+    }
+    
+    /// 문장에 혼합 단어가 있는지 확인
+    pub fn has_mixed_words(text: &str) -> bool {
+        let words = Self::parse_sentence(text);
+        words.iter().any(|word| Self::is_mixed_word(word))
+    }
+    
+    /// 문장의 언어 주체 판단
+    pub fn determine_language_dominance(text: &str) -> LanguageDominance {
+        // 1. 혼합 단어가 있으면 한글 문장
+        if Self::has_mixed_words(text) {
+            return LanguageDominance::Korean;
+        }
+        
+        // 2. 혼합 단어가 없으면 비율 기반 판단
+        let words = Self::parse_sentence(text);
+        let total_words = words.len();
+        
+        if total_words == 0 {
+            return LanguageDominance::English;
+        }
+        
+        let korean_words = words.iter()
+            .filter(|word| word.chars().any(|c| utils::is_korean_char(c)))
+            .count();
+        
+        let english_words = words.iter()
+            .filter(|word| word.chars().all(|c| c.is_ascii_alphabetic()))
+            .count();
+        
+        let korean_ratio = korean_words as f64 / total_words as f64;
+        let english_ratio = english_words as f64 / total_words as f64;
+        
+        if korean_ratio > english_ratio {
+            LanguageDominance::Korean
+        } else if english_ratio > korean_ratio {
+            LanguageDominance::English
+        } else {
+            // 비율이 같으면 첫 단어 기준
+            if let Some(first_word) = words.first() {
+                if first_word.chars().any(|c| utils::is_korean_char(c)) {
+                    LanguageDominance::Korean
+                } else {
+                    LanguageDominance::English
+                }
+            } else {
+                LanguageDominance::English
+            }
+        }
+    }
+}
+
+/// 문장의 언어 주체
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LanguageDominance {
+    Korean,   // 한글이 주체
+    English,  // 영어가 주체
+}
+


### PR DESCRIPTION
안녕하세요, #89 와 관련된 조항들을 살펴보다가 일단 영어 문장 / 한글 문장 판별 여부를 확인하는 모듈을 구성했습니다. 병합을 요청드리려고 올린 것은 아니고, 같이 논의를 해봐야하는 부분들이 있을 듯 해서 pr을 먼저 올렸습니다!


이와 관련한 조항은 30항 다만, 39항이 있습니다. 이 조항들 때문에 문장 전체가 영어가 위주인지 한글이 위주인지 파악이 필요하게 됩니다.

<img width="761" height="59" alt="image" src="https://github.com/user-attachments/assets/6c6daed1-779c-408c-a47e-63281a5e643f" />

<img width="748" height="90" alt="image" src="https://github.com/user-attachments/assets/f4c48a61-1854-4e45-a7af-7eeec30f0211" />

처음에는 문장 여부 판별 (30항 다만, 39항) -> 로마자 종료 규칙 적용 (31 ~ 35항) 순으로 진행하려고 했는데, 로마자 종료 규칙 적용과 관련된 PR #90 이 깔끔하게 정리된 상황이라, **해당 PR을 확인하신 이후에 39항 한글표 삽입 여부 로직을 추가할 수 있을 듯 하여 한글/영어 문장 판별 여부 모듈만 우선 공유드립니다.**


### 구조

영어 문장, 한글 문장 판별 여부는 사실 주관적인 부분이 강하기 때문에 룰 베이스로 적용하기가 까다로워 고민 후에 아래와 같은 구조로 결정했습니다.

- 기존처럼 공백 단위로 단어를 끊습니다.
- 영어와 한글이 섞여나오는 단어가 한개라도 있다면 한글 문장으로 판별합니다.
- 그렇지 않다면 영어 단어와 한글 단어의 비율을 비교해서 더 많은 쪽으로 판별합니다.

이렇게 진행한 이유는 한국어의 특성상 영어 단어나 문장이 끼어들어도 같은 단어 내에서 한글 등장 확률이 높기 때문입니다. 반대로 영어의 경우엔 영어 문장에 한글 단어가 껴있더라도 웬만하면 영어가 붙어서 나오지는 않습니다.

ex. 1차 세계 대전 당시 영국의 왕은 George V였다.
ex. be, his, was, were의 약자를 바르게 쓰시오.
ex. What is 김치 in English?

룰베이스로 진행하다보니 잠정적으로 안맞는 케이스가 나올 수 있을텐데, 이는 비율을 조정해서 최적화하는 방향으로 맞춰갈 수 있지 않을까 싶습니다. 특히 통일 영어 점자 규정이 영어 표기 방법도 일부 다르다보니 영어 여부 / 한글 여부는 결국 필요할 것으로 보이긴 해서 더 좋은 방법 있으면 제안 주셔도 좋을 거 같습니다!

