### PR TITLE
Update cli.rs

### DIFF
--- a/libs/braillify/src/cli.rs
+++ b/libs/braillify/src/cli.rs
@@ -40,7 +40,7 @@ fn run_repl() -> Result<()> {
     let mut stdout = io::stdout();
     writeln!(
         stdout,
-        "braillify REPL - 입력을 점자로 변환합니다. 종료: Ctrl+C or Ctrl+D"
+        "braillify REPL - 입력을 점자로 변환합니다. 종료: Ctrl+C or Ctrl+D or Crtl+Z"
     )?;
     stdout.flush()?;
 


### PR DESCRIPTION
#88 
Windows environment에 대한 EOF 입력에 따른 출력 개선
Line 43

``"braillify REPL - 입력을 점자로 변환합니다. 종료: Ctrl+C or Ctrl+D"``
->
``"braillify REPL - 입력을 점자로 변환합니다. 종료: Ctrl+C or Ctrl+D or Crtl+Z"``