### PR TITLE
Add word-break: keep-all for better Korean text rendering

### DIFF
--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -58,6 +58,7 @@ globalCss({
     // WebkitFontSmoothing: 'antialiased',
     // MozOsxFontSmoothing: 'grayscale',
     fontFamily: 'Spoqa Han Sans Neo, Arial, Helvetica, sans-serif',
+    wordBreak: 'keep-all',
   },
   '*': {
     boxSizing: 'border-box',


### PR DESCRIPTION
- 한국어 텍스트가 단어 중간에서 줄바꿈되지 않도록 word-break: keep-all 스타일 추가
- body 전역 스타일에 적용하여 모든 페이지에서 깔끔한 텍스트 표시