### PR TITLE
ci: add testcase report workflow

### DIFF
--- a/.github/workflows/testcase-report.yml
+++ b/.github/workflows/testcase-report.yml
@@ -1,0 +1,110 @@
+name: Testcase Report
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/testcase-report.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'libs/braillify/**'
+      - 'test_cases/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  testcase-report:
+    name: Testcase Report
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Run testcase report
+        id: testcase
+        shell: bash
+        run: |
+          set +e
+          cargo test test_by_testcase -- --nocapture 2>&1 | tee testcase-report.log
+          status=${PIPESTATUS[0]}
+          clean_report="$(perl -pe 's/\x1b\[[0-9;]*m//g' testcase-report.log)"
+
+          total="$(printf '%s\n' "$clean_report" | awk -F': ' '/총 테스트 케이스/ { gsub(/[^0-9]/, "", $2); print $2; exit }')"
+          passed="$(printf '%s\n' "$clean_report" | awk -F': ' '/^성공:/ { gsub(/[^0-9]/, "", $2); print $2; exit }')"
+          failed="$(printf '%s\n' "$clean_report" | awk -F': ' '/^실패:/ { gsub(/[^0-9]/, "", $2); print $2; exit }')"
+
+          total="${total:-0}"
+          passed="${passed:-0}"
+          failed="${failed:-0}"
+          success_rate="0.00"
+          if [ "$total" -gt 0 ]; then
+            success_rate="$(awk -v passed="$passed" -v total="$total" 'BEGIN { printf "%.2f", passed / total * 100 }')"
+          fi
+
+          {
+            echo '### Braillify testcase report'
+            echo
+            echo '| Metric | Count |'
+            echo '| --- | ---: |'
+            echo "| Total | $total |"
+            echo "| Passed | $passed |"
+            echo "| Failed | $failed |"
+            echo "| Success rate | $success_rate% |"
+            echo
+            echo 'Command: `cargo test test_by_testcase -- --nocapture`'
+          } > testcase-report.md
+
+          cat testcase-report.md >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo 'report<<EOF'
+            cat testcase-report.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+          exit "$status"
+
+      - name: Comment testcase report
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        env:
+          REPORT: ${{ steps.testcase.outputs.report }}
+        with:
+          script: |
+            const marker = '<!-- braillify-testcase-report -->'
+            const body = `${marker}\n${process.env.REPORT}`
+            const issue_number = context.payload.pull_request.number
+            const { owner, repo } = context.repo
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            )
+            const previous = comments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            )
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              })
+            }


### PR DESCRIPTION
## Summary
- Add a dedicated Testcase Report workflow for PRs that touch the Rust core or testcase data.
- Run `cargo test test_by_testcase -- --nocapture` and parse the total/passed/failed testcase counts.
- Write the report to the GitHub Actions summary, and update a sticky PR comment for same-repository PRs where the workflow token can write comments.

## Related Issue
- Closes #106

## Tests
- `cargo test test_by_testcase -- --nocapture`
- `actionlint .github/workflows/testcase-report.yml`

## Notes
- The workflow is intentionally separate from the publish workflow so the testcase report can stay focused and reviewable.
