### PR TITLE
fix(landing): 수학 데모의 LaTeX 안내 문구 폰트를 사이트 폰트로 통일

### DIFF
--- a/apps/landing/src/app/MathTransInput.tsx
+++ b/apps/landing/src/app/MathTransInput.tsx
@@ -110,9 +110,9 @@ export function MathTransInput({
         </VStack>
         <Text
           color="$text"
-          fontFamily="monospace"
           minH="1.5em"
           opacity={0.7}
+          typography="body"
           wordBreak="break-all"
         >
           {latex ? `LaTeX: $${latex}$` : 'LaTeX가 자동으로 생성됩니다'}

--- a/apps/landing/src/app/MathTransInput.tsx
+++ b/apps/landing/src/app/MathTransInput.tsx
@@ -59,10 +59,11 @@ export function MathTransInput({
   }, [ready])
 
   return (
-    // 폭 분배(flex)는 호출부가 맡는다. 바깥 Flex 에 padding 을 두지 않는 이유는
-    // flex-basis:0 이라도 flex 아이템의 border-box 크기가 padding 합보다 작아질 수
-    // 없어서, padding 이 있으면 그만큼 출력측 TransInput 보다 넓어지기 때문이다.
-    <Flex>
+    // 출력측 TransInput 과 마찬가지로 자기 폭은 자기가 잡는다. 바깥 Flex 에
+    // padding 을 두지 않는 이유는 flex-basis:0 이라도 flex 아이템의 border-box
+    // 크기가 padding 합보다 작아질 수 없어서, padding 이 있으면 그만큼 출력측
+    // TransInput 보다 넓어지기 때문이다.
+    <Flex flex="1" minW="0">
       <VStack
         bg="$containerBackground"
         borderRadius={['16px', null, null, '30px']}

--- a/apps/landing/src/app/MathTransPanel.tsx
+++ b/apps/landing/src/app/MathTransPanel.tsx
@@ -32,10 +32,6 @@ export function MathTransPanel() {
       flexDirection={[null, null, null, 'row']}
       gap={['12px', null, null, '30px']}
       h={['auto', null, null, '500px']}
-      // 좌우 박스가 폭을 반씩 나누도록 호출부에서 분배한다. 화살표(가운데)는 제외.
-      selectors={{
-        '&>*:first-child, &>*:last-child': { flex: 1, minWidth: 0 },
-      }}
     >
       <MathTransInput
         latex={latex}


### PR DESCRIPTION
## 무엇을

수학 점역 데모 입력 박스 하단의 `LaTeX가 자동으로 생성됩니다` 줄이 `fontFamily="monospace"` 라서 브라우저 기본 monospace(13px / weight 400)로 그려집니다. 같은 박스 안의 Spoqa Han Sans Neo 500 텍스트와 폰트·크기·자간이 모두 어긋나 보입니다.

`devup.json` 에 이미 있는 `body` 토큰(Spoqa 500, 14px → 16px)으로 바꿔 나머지 UI 와 맞췄습니다.

## 함께 정리한 것

좌우 박스의 폭 분배를 `MathTransPanel` 의 `selectors` 대신 `MathTransInput` 이 자기 루트에서 갖도록 옮겼습니다.

```diff
- selectors={{ '&>*:first-child, &>*:last-child': { flex: 1, minWidth: 0 } }}
```

- 출력측 `TransInput` 은 이미 자기 루트에 `flex="1"` 을 갖고 있어서, 같은 역할의 두 형제가 서로 다른 방식으로 폭을 얻고 있었습니다 (막내는 `flex:1` 을 자기 자신과 부모 선택자 양쪽에서 중복으로 받았습니다)
- `:first-child` / `:last-child` 는 자식 순서에 의존합니다. 앞뒤로 요소가 하나만 끼어들어도 엉뚱한 자식이 폭을 가져갑니다
- 렌더 결과는 동일합니다

`padding` 없는 바깥 래퍼를 유지해야 하는 이유(64330ed)는 주석으로 남겼습니다.

## 검증

`bun -F landing build` 로 클린 프로덕션 빌드 후 정적 서빙하여 확인했습니다.

| | before | after |
|---|---|---|
| LaTeX 줄 | monospace 13px / 400 | Spoqa Han Sans Neo 16px / 500 |
| 좌 / 우 박스 폭 | 498 / 498 | 498 / 498 (동일, 회귀 없음) |

- 데스크톱(row) · 모바일(column) 레이아웃 모두 확인
- 한글 탭 회귀 없음
- `cargo test -p braillify` 4,269 통과 / 0 실패, `bun test` 14,171 통과 / 0 실패
- `oxlint` 클린

## ⚠️ 참고 — 이 PR 로는 해결되지 않는 것

현재 https://braillify.kr 의 수학 탭은 좌우 폭이 **433 / 577** 로 어긋나고 안내 문구가 회색이 아닌 검은색으로 보입니다. **이건 소스 문제가 아니라 배포본 CSS 가 소스와 불일치하기 때문입니다.** 같은 커밋을 클린 빌드하면 로컬에서는 정상입니다.

같은 원인으로 **전 페이지 상단 GNB 도 스타일이 빠진 채 나오고 있습니다.** 별도 이슈로 올렸습니다 → #182

이 PR 은 그와 별개로 실재하는 폰트 문제를 고치고, 폭 분배가 이 파일에서만 새로 생성되는 CSS 규칙에 의존하지 않도록 함께 정리한 것입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
