### PR TITLE
ci(node): npm 배포를 Trusted Publishing(OIDC)으로 전환

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -481,17 +481,40 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: packages/node/pkg/*
+      # npm (not bun) performs the publish, and it needs `registry-url` here:
+      # that is what writes the registry line into the job's .npmrc, which is
+      # what npm exchanges the Actions OIDC token against. Without it npm has
+      # no registry to authenticate to and falls back to an anonymous PUT,
+      # which the registry answers with a 404 rather than a 401.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1. Node 24 bundles the
+      # 11.x line but not necessarily a new enough patch, so pin it explicitly
+      # rather than depending on whichever npm the runner image happens to
+      # carry.
+      - name: Ensure npm >= 11.5.1 (OIDC floor)
+        run: npm install -g 'npm@^11'
       # - name: Move artifacts
       #   run: bun run artifacts
       #   working-directory: packages/node
       # - name: List packages
       #   run: ls -R ./npm
       #   working-directory: packages/node
+      # Publishes with Trusted Publishing (OIDC): npm exchanges the job's
+      # `id-token` for a short-lived registry credential, so no NPM_TOKEN is
+      # written to .npmrc. Writing one would actually BREAK this - npm prefers
+      # an explicit `_authToken` and never starts the OIDC exchange when it
+      # finds one.
+      #
+      # This requires a trusted publisher registered for `braillify` on
+      # npmjs.com pointing at dev-five-git/braillify and this workflow file;
+      # without it the registry rejects the exchange.
       - name: Publish
         run: |
           # bun install -g @napi-rs/cli
           bun run build
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
           # package.json 의 현재 버전이 이미 npm 에 publish 되어 있으면 nothing to do.
           # (버전을 bump 하면 새 버전은 아직 존재하지 않으므로 정상 publish 됨)
@@ -505,7 +528,6 @@ jobs:
           npm publish --access public
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/node
       # - name: Upload Asset
       #   uses: owjs3901/upload-github-release-asset@main


### PR DESCRIPTION
## 확인 결과: OIDC는 적용되어 있지 않았습니다

`Node Publish` 잡은 `permissions: id-token: write` 를 선언만 해두고 실제로는 쓰지 않고 있었습니다. 발행은 classic token 방식이었습니다.

```yaml
echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
...
npm publish --access public
```

그리고 이 잡에는 `actions/setup-node` 자체가 없어서 `registry-url` 도 설정되지 않았습니다.

## 실패 로그

[run 33306219287 / Node Publish](https://github.com/dev-five-git/braillify/actions/runs/33306219287/job/99246319388) — 패키징까지는 정상이고 마지막 PUT 에서 실패합니다.

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/braillify - Not found
npm error 404  'braillify@2.1.1' is not in this registry.
```

`braillify@2.1.0` 은 레지스트리에 정상 존재합니다. npm 은 권한 없는 publish 를 401 이 아니라 **404** 로 답하기 때문에 "패키지가 없다"처럼 보이지만, 실제로는 인증이 통과하지 못한 것입니다.

## 변경

| | |
|---|---|
| `actions/setup-node@v7` + `registry-url` 추가 | OIDC 교환의 전제. 이 액션이 job 의 `.npmrc` 에 레지스트리 줄을 써주고, npm 은 그 레지스트리를 상대로 Actions OIDC 토큰을 단명 자격증명으로 교환합니다. 없으면 npm 은 인증 대상 자체가 없어 익명 PUT 을 보내고 위 404 를 받습니다. |
| `npm install -g 'npm@^11'` | Trusted Publishing 은 npm >= 11.5.1 필요. Node 24 가 11.x 를 번들하지만 패치 버전은 러너 이미지에 달려 있어 명시적으로 고정했습니다. |
| `_authToken` 기록 및 `NPM_TOKEN` env 제거 | 토큰이 남아 있으면 npm 이 그것을 우선하고 **OIDC 교환을 아예 시작하지 않습니다.** 병행이 불가능해 제거가 필수입니다. |

같은 조직의 [changepacks/changepacks 의 `node-publish`](https://github.com/changepacks/changepacks/blob/main/.github/workflows/CI.yml) 가 이미 이 형태로 동작 중이라 그 구성을 따랐습니다. (다만 changepacks 의 `npm < 12` 상한은 `@napi-rs/cli` 호환 때문이고, braillify 는 wasm-pack 기반이라 그 제약과는 무관합니다.)

## ⚠️ 머지 전에 필요한 수동 작업

**npmjs.com 에서 `braillify` 패키지에 trusted publisher 를 등록해야 합니다.** 이건 워크플로 파일로 할 수 없고 npm 계정 권한이 필요합니다.

`npmjs.com` → `braillify` → **Settings** → **Trusted Publisher** → GitHub Actions:

| 항목 | 값 |
|---|---|
| Organization / User | `dev-five-git` |
| Repository | `braillify` |
| Workflow filename | `publish.yml` |
| Environment | (비워둠) |

등록하지 않은 상태로 머지하면 토큰 방식마저 사라지므로 교환이 거부됩니다. 등록 후 재실행하면 발행됩니다.

## 정리

`NPM_TOKEN` 은 이제 어떤 워크플로에서도 참조되지 않습니다. trusted publisher 등록과 첫 성공 발행을 확인한 뒤 repository secret 에서 제거하셔도 됩니다.

Python(`MATURIN_PYPI_TOKEN`), NuGet(`NUGET_API_KEY`), crates.io(`CARGO_REGISTRY_TOKEN`) 는 이번 범위 밖이라 그대로 두었습니다. PyPI 도 trusted publishing 을 지원하니 원하시면 이어서 정리하겠습니다.
